### PR TITLE
refactor: inferred types from stitches

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,14 +1,14 @@
 import * as s from './button.styles';
+import { modifyVariantsForStory, VariantProps } from 'styles/utils/type-utils';
 
-export type ButtonProps = {
+type ButtonVariants = VariantProps<typeof s.ButtonWrapper>;
+export type ButtonProps = ButtonVariants & {
   children: React.ReactNode;
-  variant?: 'primary' | 'secondary';
   type?: 'button' | 'submit' | 'reset';
-  isFullWidth?: boolean;
   onClick?: () => void;
 };
 
-const Button = ({
+export const Button = ({
   children,
   variant = 'primary',
   type = 'button',
@@ -27,4 +27,6 @@ const Button = ({
   );
 };
 
-export { Button };
+export const ButtonStory = modifyVariantsForStory<ButtonVariants, ButtonProps>(
+  Button
+);

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -1,10 +1,10 @@
-import { Story, Meta } from '@storybook/react/types-6-0';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-import { Button, ButtonProps } from './Button';
+import { ButtonStory } from './Button';
 
-const story: Meta<ButtonProps> = {
+const story: ComponentMeta<typeof ButtonStory> = {
   title: 'Atoms/Button',
-  component: Button,
+  component: ButtonStory,
   args: {
     variant: 'primary',
     children: 'Button',
@@ -27,9 +27,9 @@ const story: Meta<ButtonProps> = {
   parameters: {}
 };
 
-export const ButtonExample: Story<ButtonProps> = args => {
+export const ButtonExample: ComponentStory<typeof ButtonStory> = args => {
   const { children } = args;
-  return <Button {...args}>{children}</Button>;
+  return <ButtonStory {...args}>{children}</ButtonStory>;
 };
 
 export default story;

--- a/src/styles/utils/type-utils.ts
+++ b/src/styles/utils/type-utils.ts
@@ -1,0 +1,29 @@
+import type * as Stitches from '@stitches/react';
+export type { VariantProps } from '@stitches/react';
+interface StitchesMedia {
+  [x: string]: any;
+  initial?: any;
+  as?: any;
+  css?: Stitches.CSS;
+}
+
+// We exclude these type properties from the `ComponentVariants` type so that storybook can more
+// easily understand the type arguments. We exclude `"true"` and `"false"` strings as well since
+// stitches also adds these, and they aren't necessary for storybook controls.
+export type StitchesPropsToExclude = 'true' | 'false' | StitchesMedia;
+
+export function modifyVariantsForStory<ComponentVariants, ComponentProps>(
+  component: (props: ComponentProps) => JSX.Element
+) {
+  type ComponentStoryVariants = {
+    [Property in keyof ComponentVariants]: Exclude<
+      ComponentVariants[Property],
+      StitchesPropsToExclude
+    >;
+  };
+
+  type ComponentStoryProps = Omit<ComponentProps, keyof ComponentVariants> &
+    ComponentStoryVariants;
+
+  return component as unknown as (props: ComponentStoryProps) => JSX.Element;
+}


### PR DESCRIPTION
#1 This approach eliminates the need to write your own types for the Stitches variants and also helps in storybook controls to be auto-generated.